### PR TITLE
.sch.uk addresses with dashes

### DIFF
--- a/lib/validates_email/email_validator.rb
+++ b/lib/validates_email/email_validator.rb
@@ -6,7 +6,7 @@ class EmailValidator < ActiveModel::EachValidator
   LocalPartSpecialChars = Regexp.escape('!#$%&\'*-/=?+-^_`{|}~')
   LocalPartUnquoted = '(([[:alnum:]' + LocalPartSpecialChars + ']+[\.\+]+))*[[:alnum:]' + LocalPartSpecialChars + '+]+'
   LocalPartQuoted = '\"(([[:alnum:]' + LocalPartSpecialChars + '\.\+]*|(\\\\[\x00-\xFF]))*)\"'
-  Regex = Regexp.new('^((' + LocalPartUnquoted + ')|(' + LocalPartQuoted + ')+)@(((\w+\-+[^_])|(\w+\.[^_]))*([a-z0-9-]{1,63})\.[a-z]{2,6}$)', Regexp::EXTENDED | Regexp::IGNORECASE, 'n')
+  Regex = Regexp.new('^((' + LocalPartUnquoted + ')|(' + LocalPartQuoted + ')+)@(((\w+\-+[^_])|(\w+\.[^_]))*([a-z0-9-]{1,63})\.[a-z]{2,6}(?:\.[a-z]{2,6})?$)', Regexp::EXTENDED | Regexp::IGNORECASE, 'n')
 
   # Validates email address.
   # If MX fallback was also requested, it will check if email is valid

--- a/spec/validates_email_spec.rb
+++ b/spec/validates_email_spec.rb
@@ -27,7 +27,9 @@ describe EmailValidator do
         '!def!xyz%abc@example.com',
         '_somename@example.com',
         # apostrophes
-        "test'test@example.com"
+        "test'test@example.com",
+        # .sch.uk
+        'valid@example.w-dash.sch.uk'
       ].each do |email|
         person = Person.new(:primary_email => email)
         person.should be_valid(email)


### PR DESCRIPTION
I suppose these addresses don't conform to the RFCs, but we've had users with .sch.uk addresses that failed the existing validation. Feel free to pull if you'd like to support these.
