### PR TITLE
Handle Encoding::CompatibilityError exception

### DIFF
--- a/lib/validates_email/email_validator.rb
+++ b/lib/validates_email/email_validator.rb
@@ -44,7 +44,11 @@ class EmailValidator < ActiveModel::EachValidator
       return false
     end
 
-    email =~ Regex and not email =~ /\.\./ and domain.length <= 255 and local.length <= 64
+    begin
+      email =~ Regex and not email =~ /\.\./ and domain.length <= 255 and local.length <= 64
+    rescue Encoding::CompatibilityError
+      return false
+    end
   end
 
   # Checks email is its domain is valid. Fallbacks to A record if requested.


### PR DESCRIPTION
Hi!

Sorry, don't know how to test this, but I have two rare email addresses who crash the plugin:
/Users/sekrett/.rvm/gems/ruby-1.9.2-p180/gems/spectator-validates_email-0.0.4/lib/validates_email/email_validator.rb:48:in `=~': incompatible encoding regexp match (ASCII-8BIT regexp with UTF-8 string) (Encoding::CompatibilityError)

This patch helps.
