### PR TITLE
Rails 3.1 compatibility

### DIFF
--- a/spectator-validates_email.gemspec
+++ b/spectator-validates_email.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_dependency "actionpack",  "~> 3.0.0"
-  s.add_dependency "activemodel", "~> 3.0.0"
+  s.add_dependency "actionpack",  ">= 3.0.0"
+  s.add_dependency "activemodel", ">= 3.0.0"
 
   s.add_development_dependency "bundler", "~> 1.0.0"
   s.add_development_dependency "rspec", "~> 2.0.0"


### PR DESCRIPTION
Updates the gemspec to allow Rails 3.1 to work with the gem. (=< 3.0.0 vs. ~< 3.0.0)
