### PR TITLE
1337 change email validation regex a bit looser so it accepts subdomains

### DIFF
--- a/lib/validates_email/email_validator.rb
+++ b/lib/validates_email/email_validator.rb
@@ -9,7 +9,7 @@ class EmailValidator < ActiveModel::EachValidator
   LocalPartSpecialChars = Regexp.escape('!#$%&\'*-/=?+-^_`{|}~')
   LocalPartUnquoted = '(([[:alnum:]' + LocalPartSpecialChars + ']+[\.\+]+))*[[:alnum:]' + LocalPartSpecialChars + '+]+'
   LocalPartQuoted = '\"(([[:alnum:]' + LocalPartSpecialChars + '\.\+]*|(\\\\[\x00-\xFF]))*)\"'
-  Regex = Regexp.new('^((' + LocalPartUnquoted + ')|(' + LocalPartQuoted + ')+)@(((\w+\-+[^_])|(\w+\.[^_]))*([a-z0-9-]{1,63})\.[a-z]{2,6}(?:\.[a-z]{2,6})?$)', Regexp::EXTENDED | Regexp::IGNORECASE, 'n')
+  Regex = Regexp.new('^((' + LocalPartUnquoted + ')|(' + LocalPartQuoted + ')+)@([a-z\d\-.]+(\.[a-z]{2,6})$)', Regexp::EXTENDED | Regexp::IGNORECASE, 'n')
 
   # Validates email address.
   # If MX fallback was also requested, it will check if email is valid

--- a/spec/validates_email_spec.rb
+++ b/spec/validates_email_spec.rb
@@ -30,7 +30,13 @@ describe EmailValidator do
         # apostrophes
         "test'test@example.com",
         # .sch.uk
-        'valid@example.w-dash.sch.uk'
+        'valid@example.w-dash.sch.uk',
+        # extra tests for an updated regex expression
+        'miss@g-c.demon.co.uk',
+        'niceandsimple@example.com',
+        'simplewithsymbol@example.com',
+        'less.common@example.com',
+        'a.little.more.unusual@dept.example.com',
       ].each do |email|
         person = Person.new(:primary_email => email)
         person.should be_valid(email)
@@ -69,7 +75,19 @@ describe EmailValidator do
         'invali d@example.com',
         'invalidexample.com',
         'invalid@example.',
-        'чебурашка@kremlin.ru'
+        'чебурашка@kremlin.ru',
+        # adding extra invalid emails for the new regex expression
+        'Abc.example.com',
+        'Abc.@example.com',
+        'Abc..123@example.com',
+        'A@b@c@example.com',
+        %w(a"b(c)d,e:f;g<h>i[j\k]l@example.com),
+        %w(just"not"right@example.com),
+        %w(this is"not\allowed@example.com),
+        %w(this\ still\"not\\allowed@example.com),
+        'blah@.....com',
+        %w(()<>[]:,;@\\\"!#$%&'*+-/=?^_`{}| ~  ? ^_`{}|~.a@example.org),
+        'joe;blogs:55@example.com'
       ].each do |email|
         person = Person.new(:primary_email => email)
         person.should_not be_valid(email)


### PR DESCRIPTION
I changed the regex expression to not be as strict. This came about with the above bug not allowing a hypen in the domain.
