### PR TITLE
Allow longer TLDs

### DIFF
--- a/lib/validates_email/email_validator.rb
+++ b/lib/validates_email/email_validator.rb
@@ -6,7 +6,7 @@ class EmailValidator < ActiveModel::EachValidator
   LocalPartSpecialChars = Regexp.escape('!#$%&\'*-/=?+-^_`{|}~')
   LocalPartUnquoted = '(([[:alnum:]' + LocalPartSpecialChars + ']+[\.\+]+))*[[:alnum:]' + LocalPartSpecialChars + '+]+'
   LocalPartQuoted = '\"(([[:alnum:]' + LocalPartSpecialChars + '\.\+]*|(\\\\[\x00-\xFF]))*)\"'
-  Regex = Regexp.new('^((' + LocalPartUnquoted + ')|(' + LocalPartQuoted + ')+)@(((\w+\-+[^_])|(\w+\.[^_]))*([a-z0-9-]{1,63})\.[a-z]{2,6}(?:\.[a-z]{2,6})?$)', Regexp::EXTENDED | Regexp::IGNORECASE, 'n')
+  Regex = Regexp.new('^((' + LocalPartUnquoted + ')|(' + LocalPartQuoted + ')+)@(((\w+\-+[^_])|(\w+\.[^_]))*([a-z0-9-]{1,63})\.[a-z]{2,63}(?:\.[a-z]{2,63})?$)', Regexp::EXTENDED | Regexp::IGNORECASE, 'n')
 
   # Validates email address.
   # If MX fallback was also requested, it will check if email is valid

--- a/spec/validates_email_spec.rb
+++ b/spec/validates_email_spec.rb
@@ -30,7 +30,9 @@ describe EmailValidator do
         # apostrophes
         "test'test@example.com",
         # .sch.uk
-        'valid@example.w-dash.sch.uk'
+        'valid@example.w-dash.sch.uk',
+        # long TLD
+        'valid@valid.helsinki'
       ].each do |email|
         person = Person.new(:primary_email => email)
         person.should be_valid(email)


### PR DESCRIPTION
The current regex limits TLDs to 6 characters. The longest one
currently issued by ICANN is 24. RFC1034 allows for up to 63
characters.